### PR TITLE
ci: setup-gradle action uses deprecated 'arguments' parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
   test:
     needs: fork
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 8
     strategy:
       matrix:
         job_sid: ${{ fromJSON(needs.fork.outputs.job_sid) }}
@@ -78,10 +78,10 @@ jobs:
           --configuration-cache
           --build-cache
           --no-daemon
+          --info
           --scan
           -DforkCount=${{ needs.fork.outputs.job_count }}
           -DforkSid=${{ matrix.job_sid }}
-          -Dsonar.gradle.skipCompile=true
 
       - name: Pack fork artifacts
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,15 +73,14 @@ jobs:
 
       - name: Test project
         run: |
-          ./gradlew test jacocoTestReport -x processResources -x processTestResources
-          --parallel
-          --configuration-cache
-          --build-cache
-          --no-daemon
-          --info
-          --scan
-          -DforkCount=${{ needs.fork.outputs.job_count }}
-          -DforkSid=${{ matrix.job_sid }}
+          ./gradlew test jacocoTestReport -x processResources -x processTestResources \
+            --parallel \
+            --configuration-cache \
+            --build-cache \
+            --no-daemon \
+            --scan \
+            -DforkCount=${{ needs.fork.outputs.job_count }} \
+            -DforkSid=${{ matrix.job_sid }}
 
       - name: Pack fork artifacts
         run: |
@@ -138,15 +137,15 @@ jobs:
 
       - name: Analyze code quality
         run: |
-          ./gradlew sonar -x compileJava -x compileTestJava
-          --parallel
-          --configuration-cache
-          --build-cache
-          --no-daemon
-          --scan
-          -Pversion=${{ format('{0}+{1}', env.VERSION, github.RUN_NUMBER) }}
-          -Dsonar.host.url=https://sonarcloud.io
-          -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.organization=${{ secrets.SONAR_KEY }}
-          -Dsonar.qualitygate.wait=true
-          -Dsonar.gradle.skipCompile=true
+          ./gradlew sonar -x compileJava -x compileTestJava \
+            --parallel \
+            --configuration-cache \
+            --build-cache \
+            --no-daemon \
+            --scan \
+            -Pversion=${{ format('{0}+{1}', env.VERSION, github.RUN_NUMBER) }} \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
+            -Dsonar.organization=${{ secrets.SONAR_KEY }} \
+            -Dsonar.qualitygate.wait=true \
+            -Dsonar.gradle.skipCompile=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,20 +66,22 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Test project
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         with:
           gradle-home-cache-cleanup: true
-          arguments: |
-            test jacocoTestReport -x processResources -x processTestResources
-            --parallel
-            --configuration-cache
-            --build-cache
-            --no-daemon
-            --scan
-            -DforkCount=${{ needs.fork.outputs.job_count }}
-            -DforkSid=${{ matrix.job_sid }}
-            -Dsonar.gradle.skipCompile=true
+
+      - name: Test project
+        run: |
+          ./gradlew test jacocoTestReport -x processResources -x processTestResources
+          --parallel
+          --configuration-cache
+          --build-cache
+          --no-daemon
+          --scan
+          -DforkCount=${{ needs.fork.outputs.job_count }}
+          -DforkSid=${{ matrix.job_sid }}
+          -Dsonar.gradle.skipCompile=true
 
       - name: Pack fork artifacts
         run: |
@@ -128,21 +130,23 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Analyze code quality
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         with:
           gradle-home-cache-cleanup: true
           add-job-summary-as-pr-comment: always
-          arguments: |
-            sonar -x compileJava -x compileTestJava
-            --parallel
-            --configuration-cache
-            --build-cache
-            --no-daemon
-            --scan
-            -Pversion=${{ format('{0}+{1}', env.VERSION, github.RUN_NUMBER) }}
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-            -Dsonar.organization=${{ secrets.SONAR_KEY }}
-            -Dsonar.qualitygate.wait=true
-            -Dsonar.gradle.skipCompile=true
+
+      - name: Analyze code quality
+        run: |
+          ./gradlew sonar -x compileJava -x compileTestJava
+          --parallel
+          --configuration-cache
+          --build-cache
+          --no-daemon
+          --scan
+          -Pversion=${{ format('{0}+{1}', env.VERSION, github.RUN_NUMBER) }}
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+          -Dsonar.organization=${{ secrets.SONAR_KEY }}
+          -Dsonar.qualitygate.wait=true
+          -Dsonar.gradle.skipCompile=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
   test:
     needs: fork
     runs-on: ubuntu-22.04
-    timeout-minutes: 8
+    timeout-minutes: 10
     strategy:
       matrix:
         job_sid: ${{ fromJSON(needs.fork.outputs.job_sid) }}


### PR DESCRIPTION
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated