### PR TITLE
build(deps): bump mockito from 5.2.0 to 5.23.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
         implementation(rootProject.libs.commons.lang3)
         compileOnly(rootProject.libs.lombok)
         annotationProcessor(rootProject.libs.lombok)
-        testImplementation(rootProject.libs.mockito.inline)
+        testImplementation(rootProject.libs.mockito)
         testImplementation(rootProject.libs.junit.jupiter)
         testImplementation(rootProject.libs.awaitility)
         testRuntimeOnly(rootProject.libs.junit.platform.launcher)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,17 @@
 [versions]
 commons-lang3 = "3.20.0"
 lombok = "1.18.46"
-mockito = "5.2.0"
+mockito = "5.23.0"
 junit = "6.1.2"
-junit-launcher = "6.1.2"
 awaitility = "4.3.0"
 sonarqube = "7.4.0.8496"
 
 [libraries]
 commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
-mockito-inline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockito" }
+mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
-junit-platform-launcher = {group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-launcher"}
+junit-platform-launcher = {group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit"}
 awaitility = { group = "org.awaitility", name = "awaitility", version.ref = "awaitility" }
 
 [plugins]


### PR DESCRIPTION
Use mockito-core instead of inline, since it was removed in 5.3.0

https://github.com/mockito/mockito/issues/3328
https://github.com/mockito/mockito/releases/tag/v5.3.0